### PR TITLE
Fixed some issues that prevent the installer from running in Windows

### DIFF
--- a/doc/appendix-A-system-administration.md
+++ b/doc/appendix-A-system-administration.md
@@ -67,6 +67,12 @@ export NOPOSTINSTALL=1    # Turns off the post-install script
 yarn install
 ```
 
+...for Windows you can use (the space after the `&&` is intentional):
+
+```dos
+set NOPREINSTALL=1&& set NOPOSTINSTALL=1&& yarn install
+```
+
 The build can be run separately from the dependency installation, but the 
 dependencies must be installed first.
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "bootstrap": "^4.3.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
+    "cross-env": "^7.0.2",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "eslint": "^6.2.1",
@@ -75,8 +76,8 @@
     "docker": "node mbee docker",
     "lint": "node mbee lint",
     "migrate": "node mbee migrate",
-    "postinstall": "test $NOPOSTINSTALL || node mbee build",
-    "preinstall": "test $NOPREINSTALL || node ./scripts/clean.js --all",
+    "postinstall": "cross-env-shell \"node mbee test $NOPOSTINSTALL\" || node mbee build",
+    "preinstall": "cross-env-shell \"node mbee test $NOPREINSTALL\" || node ./scripts/clean.js --all",
     "start": "node mbee start",
     "test": "node mbee test",
     "watch": "./node_modules/.bin/webpack --watch --config scripts/webpack-dev.config.js"

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -62,8 +62,17 @@ function clean(_args) {
 
   // Clean logs
   if (args.length === 0 || args.includes('--all')) {
-    log('Cleaning logs...');
-    execSync(`${rmd} ${path.join(root, 'build')} ${path.join(root, 'logs')}`);
+    const build_path = `${path.join(root, 'build')}`;
+    if (fs.existsSync(build_path)) {
+      log('Cleaning build...')
+      execSync(`${rmd} ${build_path}`);
+    }
+
+    const logs_path = `${path.join(root, 'logs')}`;
+    if (fs.existsSync(logs_path)) {
+      log('Cleaning logs...');
+      execSync(`${rmd} ${logs_path}`);
+    }
   }
 
   // Clean data


### PR DESCRIPTION
Fixed some issues that prevent the installer from running in Windows, namely:

* `postinstall` and `preinstall` commands
* The log cleaning commands fail if the folders are not there because `RMDIR /S /Q` is not as good as `rm -rf`...  There is no flag to make it not fail if the file/folder specified does not exist

Also updated the instructions in Appendix A to correctly set the install environmental variables correctly in Windows.